### PR TITLE
support time.Duration default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ type ExampleBasic struct {
     Foo bool   `default:"true"` //<-- StructTag with a default key
     Bar string `default:"33"`
     Qux int8
+    Dur time.Duration `default:"1m"`
 }
 
 func NewExampleBasic() *ExampleBasic {
@@ -42,7 +43,7 @@ test := NewExampleBasic()
 fmt.Println(test.Foo) //Prints: true
 fmt.Println(test.Bar) //Prints: 33
 fmt.Println(test.Qux) //Prints:
-
+fmt.Println(test.Dur) //Prints: 1m0s
 ```
 
 License

--- a/defaults.go
+++ b/defaults.go
@@ -3,6 +3,7 @@ package defaults
 import (
 	"reflect"
 	"strconv"
+	"time"
 )
 
 // Applies the default values to the struct object, the struct type must have
@@ -84,5 +85,11 @@ func newDefaultFiller() *Filler {
 		getDefaultFiller().SetDefaultValues(fields)
 	}
 
-	return &Filler{FuncByKind: funcs, Tag: "default"}
+	types := make(map[TypeHash]FillerFunc, 1)
+	types["time.Duration"] = func(field *FieldData) {
+		d, _ := time.ParseDuration(field.TagValue)
+		field.Value.Set(reflect.ValueOf(d))
+	}
+
+	return &Filler{FuncByKind: funcs, FuncByType: types, Tag: "default"}
 }

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 )
@@ -33,6 +34,7 @@ type ExampleBasic struct {
 		Bool    bool `default:"true"`
 		Integer int  `default:"33"`
 	}
+	Duration time.Duration `default:"1s"`
 }
 
 func (s *DefaultsSuite) TestSetDefaultsBasic(c *C) {
@@ -70,6 +72,7 @@ func (s *DefaultsSuite) assertTypes(c *C, foo *ExampleBasic) {
 	c.Assert(foo.Float32, Equals, float32(3.2))
 	c.Assert(foo.Float64, Equals, 6.4)
 	c.Assert(foo.Struct.Bool, Equals, true)
+	c.Assert(foo.Duration, Equals, time.Second)
 }
 
 func (s *DefaultsSuite) TestSetDefaultsWithValues(c *C) {


### PR DESCRIPTION
Based on the feedback on https://github.com/mcuadros/go-defaults/pull/2, here is the updated version that uses `FuncByType` in the filler.

ping @mcuadros 
cc @russmatney 