### PR TITLE
add support to fill in slice of structs

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -71,12 +71,19 @@ func newDefaultFiller() *Filler {
 	}
 
 	funcs[reflect.Slice] = func(field *FieldData) {
-		if field.Value.Type().Elem().Kind() == reflect.Uint8 {
+		k := field.Value.Type().Elem().Kind()
+		switch k {
+		case reflect.Uint8:
 			if field.Value.Bytes() != nil {
 				return
 			}
-
 			field.Value.SetBytes([]byte(field.TagValue))
+		case reflect.Struct:
+			count := field.Value.Len()
+			for i := 0; i < count; i++ {
+				fields := getDefaultFiller().GetFieldsFromValue(field.Value.Index(i), nil)
+				getDefaultFiller().SetDefaultValues(fields)
+			}
 		}
 	}
 

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -14,6 +14,15 @@ type DefaultsSuite struct{}
 
 var _ = Suite(&DefaultsSuite{})
 
+type Parent struct {
+	Children []Child
+}
+
+type Child struct {
+	Name string
+	Age  int `default:"10"`
+}
+
 type ExampleBasic struct {
 	Bool       bool    `default:"true"`
 	Integer    int     `default:"33"`
@@ -35,6 +44,7 @@ type ExampleBasic struct {
 		Integer int  `default:"33"`
 	}
 	Duration time.Duration `default:"1s"`
+	Children []Child
 }
 
 func (s *DefaultsSuite) TestSetDefaultsBasic(c *C) {
@@ -73,6 +83,7 @@ func (s *DefaultsSuite) assertTypes(c *C, foo *ExampleBasic) {
 	c.Assert(foo.Float64, Equals, 6.4)
 	c.Assert(foo.Struct.Bool, Equals, true)
 	c.Assert(foo.Duration, Equals, time.Second)
+	c.Assert(foo.Children, IsNil)
 }
 
 func (s *DefaultsSuite) TestSetDefaultsWithValues(c *C) {
@@ -82,6 +93,7 @@ func (s *DefaultsSuite) TestSetDefaultsWithValues(c *C) {
 		Float32:  9.9,
 		String:   "bar",
 		Bytes:    []byte("foo"),
+		Children: []Child{{Name: "alice"}, {Name: "bob", Age: 2}},
 	}
 
 	SetDefaults(foo)
@@ -91,6 +103,8 @@ func (s *DefaultsSuite) TestSetDefaultsWithValues(c *C) {
 	c.Assert(foo.Float32, Equals, float32(9.9))
 	c.Assert(foo.String, Equals, "bar")
 	c.Assert(string(foo.Bytes), Equals, "foo")
+	c.Assert(foo.Children[0].Age, Equals, 10)
+	c.Assert(foo.Children[1].Age, Equals, 2)
 }
 
 func (s *DefaultsSuite) BenchmarkLogic(c *C) {

--- a/filler.go
+++ b/filler.go
@@ -85,8 +85,13 @@ func (f *Filler) isEmpty(field *FieldData) bool {
 			return false
 		}
 	case reflect.Slice:
-		if field.Value.Len() != 0 {
-			return false
+		switch field.Value.Type().Elem().Kind() {
+		case reflect.Struct:
+			// always assume the structs in the slice is empty and can be filled
+			// the actually struct filling logic should take care of the rest
+			return true
+		default:
+			return field.Value.Len() == 0
 		}
 	case reflect.String:
 		if field.Value.String() != "" {


### PR DESCRIPTION
This allows us to fill in slice of structs, something like
```
type Parent struct {
   ...
   Children []Child
}
type Child struct {
   Name string
   Age     int  `default:"5"`
}
```

In my projects which I'm now starting to use this library, there are many cases with deep nested configs where some of them are slices of struct, and this will help me setting defaults on all those level.

I hope this is useful addition to this library, would you please take a look and let me know if there is anything I can improve @mcuadros 😺 