### PR TITLE
add caveats about zero value

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ fmt.Println(test.Qux) //Prints:
 fmt.Println(test.Dur) //Prints: 1m0s
 ```
 
+Caveats
+-------
+
+At the moment, the way the default filler checks whether it should fill a struct field or not is by comparing the current field value with the corresponding zero value of that type. This has a subtle implication: the zero value set explicitly by you will get overriden by default value during `SetDefaults()` call. So if you need to set the field to container zero value, you need to set it explicitly AFTER setting the defaults.
+
+Take the basic example in the above section and change it slightly:
+```go
+
+example := ExampleBasic{
+    Bar: 0,
+}
+defaults.SetDefaults(example)
+fmt.Println(example.Bar) //Prints: 33 instead of 0 (which is zero value for int)
+
+example.Bar = 0 // set needed zero value AFTER applying defaults
+fmt.Println(example.Bar) //Prints: 0
+
+```
+
 License
 -------
 


### PR DESCRIPTION
I just found out about this during my last PR. For things like timeout configurable or max number of retry, zero value  `0` means no timeout or indefinitely retry and can appear in configuration yaml files. If `SetDefaults()` is called **after** parsing the yaml, the zero value is overridden.

So I think it might be beneficial to put this in a caveat section to raise awareness so people don't trip over it. Otherwise it's entirely optional.

ping @mcuadros 