### PR TITLE
add Feature Parse DateTime String

### DIFF
--- a/defaults_test.go
+++ b/defaults_test.go
@@ -4,11 +4,20 @@ import (
 	"testing"
 	"time"
 
+	"bou.ke/monkey"
 	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+
+func Test(t *testing.T) {
+	monkey.Patch(time.Now, func() time.Time {
+		t, _ := time.Parse("2006-01-02 15:04:05", "2020-06-10 12:00:00")
+		return t
+	})
+
+	TestingT(t)
+}
 
 type DefaultsSuite struct{}
 
@@ -50,6 +59,8 @@ type ExampleBasic struct {
 	IntSlice         []int         `default:"[1,2,3,4]"`
 	IntSliceSlice    [][]int       `default:"[[1],[2],[3],[4]]"`
 	StringSliceSlice [][]string    `default:"[[1],[]]"`
+
+	DateTime string `default:"{{date:1,-10,0}} {{time:1,-5,10}}"`
 }
 
 func (s *DefaultsSuite) TestSetDefaultsBasic(c *C) {
@@ -94,6 +105,7 @@ func (s *DefaultsSuite) assertTypes(c *C, foo *ExampleBasic) {
 	c.Assert(foo.IntSlice, DeepEquals, []int{1, 2, 3, 4})
 	c.Assert(foo.IntSliceSlice, DeepEquals, [][]int{[]int{1}, []int{2}, []int{3}, []int{4}})
 	c.Assert(foo.StringSliceSlice, DeepEquals, [][]string{[]string{"1"}, []string{}})
+	c.Assert(foo.DateTime, Equals, "2020-08-10 12:55:10")
 }
 
 func (s *DefaultsSuite) TestSetDefaultsWithValues(c *C) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mcuadros/go-defaults
+module github.com/pagongamedev/go-defaults
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mcuadros/go-defaults
 go 1.14
 
 require (
+	bou.ke/monkey v1.0.2 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=


### PR DESCRIPTION
parse string date time with syntax 

{{date:+-<year>,+-<month>,+-<day>}}
for set default by date now + year+month+day

and
{{time:+-<hour>,+-<minute>,+-<second>}}
for set default by time now + hour+miniute+second

Example
```
	DateTime string `default:"{{date:1,-10,0}} {{time:1,-5,10}}"`
```
return "2020-08-10 12:55:10"
