### PR TITLE
Fix race condition in init by using sync.Once

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -25,12 +26,15 @@ func SetDefaults(variable interface{}) {
 	getDefaultFiller().Fill(variable)
 }
 
-var defaultFiller *Filler = nil
+var (
+	defaultFillerOnce sync.Once
+	defaultFiller     *Filler = nil
+)
 
 func getDefaultFiller() *Filler {
-	if defaultFiller == nil {
+	defaultFillerOnce.Do(func() {
 		defaultFiller = newDefaultFiller()
-	}
+	})
 
 	return defaultFiller
 }

--- a/factory.go
+++ b/factory.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"math/rand"
 	"reflect"
+	"sync"
 	"time"
 )
 
@@ -12,12 +13,15 @@ func Factory(variable interface{}) {
 	getFactoryFiller().Fill(variable)
 }
 
-var factoryFiller *Filler = nil
+var (
+	factoryFillerOnce sync.Once
+	factoryFiller     *Filler = nil
+)
 
 func getFactoryFiller() *Filler {
-	if factoryFiller == nil {
+	factoryFillerOnce.Do(func() {
 		factoryFiller = newFactoryFiller()
-	}
+	})
 
 	return factoryFiller
 }


### PR DESCRIPTION
When this package is used in parallel (for example for web requests), the initialization of filler presents a race condition.
This was detected by using go's race detector.
The fix is to use `sync.Once` for intialization.