### PR TITLE
Fixed a problem where `default: "1000000000"` in time.Duration was equal to "0".

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -89,7 +89,11 @@ func newDefaultFiller() *Filler {
 
 	types := make(map[TypeHash]FillerFunc, 1)
 	types["time.Duration"] = func(field *FieldData) {
-		d, _ := time.ParseDuration(field.TagValue)
+		d, err := time.ParseDuration(field.TagValue)
+		if err != nil {
+			v, _ := strconv.ParseInt(field.TagValue, 10, 64)
+			d = time.Duration(v)
+		}
 		field.Value.Set(reflect.ValueOf(d))
 	}
 

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -52,13 +52,14 @@ type ExampleBasic struct {
 		Bool    bool `default:"true"`
 		Integer int  `default:"33"`
 	}
-	Duration         time.Duration `default:"1s"`
-	Children         []Child
-	Second           time.Duration `default:"1s"`
-	StringSlice      []string      `default:"[1,2,3,4]"`
-	IntSlice         []int         `default:"[1,2,3,4]"`
-	IntSliceSlice    [][]int       `default:"[[1],[2],[3],[4]]"`
-	StringSliceSlice [][]string    `default:"[[1],[]]"`
+	Duration          time.Duration `default:"1s"`
+	Children          []Child
+	Second            time.Duration `default:"1s"`
+	Integer64Duration time.Duration `default:"1000000000"`
+	StringSlice       []string      `default:"[1,2,3,4]"`
+	IntSlice          []int         `default:"[1,2,3,4]"`
+	IntSliceSlice     [][]int       `default:"[[1],[2],[3],[4]]"`
+	StringSliceSlice  [][]string    `default:"[[1],[]]"`
 
 	DateTime string `default:"{{date:1,-10,0}} {{time:1,-5,10}}"`
 }
@@ -101,6 +102,7 @@ func (s *DefaultsSuite) assertTypes(c *C, foo *ExampleBasic) {
 	c.Assert(foo.Duration, Equals, time.Second)
 	c.Assert(foo.Children, IsNil)
 	c.Assert(foo.Second, Equals, time.Second)
+	c.Assert(foo.Integer64Duration, Equals, time.Second)
 	c.Assert(foo.StringSlice, DeepEquals, []string{"1", "2", "3", "4"})
 	c.Assert(foo.IntSlice, DeepEquals, []int{1, 2, 3, 4})
 	c.Assert(foo.IntSliceSlice, DeepEquals, [][]int{[]int{1}, []int{2}, []int{3}, []int{4}})


### PR DESCRIPTION
In v1.1.0, setting `default: "1000000000"` for time.Duration was equivalent to "1s". 

but, In v1.2.0, setting `default: "1000000000"` for time.Duration is equivalent to "0".

Therefore, even if time.Duration is set to a string that can be converted to int64, I did correct as "time.Duration".

#19 